### PR TITLE
Switch from Twitter to LinkedIn widget

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1737050308878
+		"lastUpdateCheck": 1743870993500
 	}
 }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -54,6 +54,6 @@ export const footerData = {
     },
   ],
   footNote: `
-    Copyright © 2024 Aadit Kamat. Built with <a class="text-blue-600 underline dark:text-muted" href="https://onwidget.com/"> onWidget</a> · All rights reserved.
+    Copyright © 2025 Aadit Kamat. Built with <a class="text-blue-600 underline dark:text-muted" href="https://onwidget.com/"> onWidget</a> · All rights reserved.
   `,
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,14 +66,7 @@ const metadata = {
           </iframe>
         </div>
         <div>
-          <a
-            class="twitter-timeline"
-            data-lang="en"
-            data-width="480"
-            data-height="425"
-            href="https://twitter.com/aaditkamat?ref_src=twsrc%5Etfw"
-            >Tweets by aaditkamat</a
-          >
+          <iframe src="https://widget.tagembed.com/2163398" style="width:100%;height:600px;border:none;"></iframe>
         </div>
       </div>
     </Fragment>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,11 @@ const metadata = {
     </Fragment>
   </Hero>
 
-  <img class="mx-auto max-w-[80%] md:max-w-[60%] lg:max-w-[40%]" src="/images/Word Cloud.png" alt="Word Cloud"/>
+  <img
+    class="mx-auto max-w-[80%] md:max-w-[60%] lg:max-w-[40%]"
+    src="/images/Word Cloud.png"
+    alt="Word Cloud"
+  />
 
   <Content isReversed title="My socials">
     <Fragment slot="content">
@@ -66,7 +70,13 @@ const metadata = {
           </iframe>
         </div>
         <div>
-          <iframe src="https://widget.tagembed.com/2163398" style="width:100%;height:600px;border:none;"></iframe>
+          <iframe
+            src="https://widget.tagembed.com/2163398"
+            title="Aadit's LinkedIn"
+            width="480"
+            height="425"
+            style="border:1px solid #EEE; background:white; margin: '0 auto';">
+          </iframe>
         </div>
       </div>
     </Fragment>


### PR DESCRIPTION
## Summary by Sourcery

Replace Twitter widget with LinkedIn widget on the personal website

Enhancements:
- Replaced the Twitter social media timeline with a LinkedIn widget to update social media integration

Chores:
- Updated copyright year from 2024 to 2025