### PR TITLE
build: update Lighthouse URL to use www subdomain

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,6 +11,6 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://aaditkamat.dev
+            https://www.aaditkamat.dev
           uploadArtifacts: true # save results as an action artifacts
           temporaryPublicStorage: false # keep lighthouse report private; do not upload to public temporary storage


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Point Lighthouse GitHub Actions workflow to https://www.aaditkamat.dev for performance audits.