### PR TITLE
fix: remove vercel assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
-# vercel
-.vercel
-
 # cloudflare
 .open-next
 .wrangler

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@opennextjs/cloudflare": "^1.19.6",
-    "@vercel/analytics": "^1.6.1",
     "autoprefixer": "10.4.24",
     "classnames": "^2.5.1",
     "next": "^16.2.6",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import {Analytics} from '@vercel/analytics/next';
 import dynamic from 'next/dynamic';
 import {FC, memo} from 'react';
 
@@ -20,7 +19,6 @@ const Home: FC = memo(() => {
   const {title, description} = homePageMeta;
   return (
     <Page description={description} title={title}>
-      <Analytics />
       <Header />
       <Hero />
       <About />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3238,11 +3238,6 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
-"@vercel/analytics@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.6.1.tgz#b4e16daf445cf6cd365a91e43d86e9e5b3428ddc"
-  integrity sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==
-
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"


### PR DESCRIPTION
## Summary by Sourcery

Remove Vercel Analytics integration from the application and dependencies.

Enhancements:
- Remove the Vercel Analytics component usage from the home page.
- Drop the @vercel/analytics package from project dependencies and lockfile.

Chores:
- Update project lockfile and config to reflect removal of Vercel assets.